### PR TITLE
Fix regression for parent Makefiles which set *_JSON_FILE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,14 @@ FLATTENED_JSON_FILE   ?= $(OUTFILE_PREFIX).flattened.json
 
 all: $(addprefix $(OUTFILE_PREFIX).,$(DEFAULT_EXTENSIONS))
 
-$(OUTFILE_PREFIX).enriched.json: $(ARTICLE_FILE) \
+$(ENRICHED_JSON_FILE): $(ARTICLE_FILE) \
 		$(PANDOC_SCHOLAR_PATH)/scholarly-metadata \
 		$(PANDOC_SCHOLAR_PATH)/writers/affiliations.lua
 	pandoc $(PANDOC_READER_OPTIONS) \
 	       -t $(PANDOC_SCHOLAR_PATH)/writers/affiliations.lua \
 	       --output $@ $<
 
-$(OUTFILE_PREFIX).flattened.json: $(ARTICLE_FILE) \
+$(FLATTENED_JSON_FILE): $(ARTICLE_FILE) \
 		$(PANDOC_SCHOLAR_PATH)/scholarly-metadata \
 		$(PANDOC_SCHOLAR_PATH)/writers/default.lua
 	pandoc $(PANDOC_READER_OPTIONS) \


### PR DESCRIPTION
The variables ENRICHED_JSON_FILE and FLATTENED_JSON_FILE are
conditionally set to allow parent Makefiles to control the location of
these intermediate targets (see 10f300e).  The commit "Improve Makefile
layout and documentation" (50fd01c) accidentally broke that feature by
changing the target recipes to use fixed filenames instead of the
variables.  I'm guessing this was a mis-merge, as the other changes that
commit makes seem unrelated.