### PR TITLE
Don't set a placeholder "Not available" abstract

### DIFF
--- a/writers/affiliations.lua
+++ b/writers/affiliations.lua
@@ -30,8 +30,6 @@ function Doc(body, meta, variables)
   end
   if next(abstract) ~= nil then
     meta.abstract = abstract
-  else
-    meta.abstract = panlunatic.Str("Not available")
   end
   return panlunatic.Doc(body, meta, variables)
 end


### PR DESCRIPTION
The templates already account for conditional abstracts and setting the
placeholder breaks that.  It's uglier to say "Not available" than to
just not include an abstract section at all.