### PR TITLE
Fix missing author affiliations in HTML output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,9 +63,11 @@ $(OUTFILE_PREFIX).epub: $(JSON_FILE) \
 
 $(OUTFILE_PREFIX).html: $(JSON_FILE) \
 		$(TEMPLATE_FILE_HTML) \
-		$(TEMPLATE_STYLE_HTML)
+		$(TEMPLATE_STYLE_HTML) \
+		$(PANDOC_SCHOLAR_PATH)/scholar-filters/template-helper.lua
 	pandoc $(PANDOC_WRITER_OPTIONS) \
 	       $(PANDOC_HTML_OPTIONS) \
+	       --lua-filter=$(PANDOC_SCHOLAR_PATH)/scholar-filters/template-helper.lua \
 	       --css=$(TEMPLATE_STYLE_HTML) \
 	       -M include-headers='<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>' \
 	       --mathjax \


### PR DESCRIPTION
The HTML template, like the PDF template, requires the template helper
filter which pre-computes useful metadata variables based on the
standard author metadata.  Its addition to the HTML target was missed in
"Use true Lua filters for document manipulations" (07e48bb).