### PR TITLE
Remove an extra space

### DIFF
--- a/templates/pandoc-scholar.html
+++ b/templates/pandoc-scholar.html
@@ -82,8 +82,7 @@ $endfor$
 </p>
 <div class="author_affiliations">
 $for(institute)$
-  <div class="affiliation"><sup>$institute.index$</sup>$institute.name$
-  $if(institute.address)$, $institute.address$$endif$
+  <div class="affiliation"><sup>$institute.index$</sup>$institute.name$$if(institute.address)$, $institute.address$$endif$
   </div>
 $endfor$
 </div>


### PR DESCRIPTION
There's an extra space after the name of the institution and before its address. For example, in the demo: `CINVESTAV Unidad Irapuato, Department of Biochemistry and Biotechnology , Km. 9.6 Libramiento Norte Carr.` should be `Biotechnology, Km`.