### PR TITLE
Only delete generated files with 'make clean'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,12 @@ $(OUTFILE_PREFIX).jats: $(JSON_FILE)
 	       --output $@ $<
 
 clean:
-	rm -f $(OUTFILE_PREFIX).*
+	@# Make sure we don't accidentally delete any other files, e.g. if the ARTICLE_FILE happens 
+	@# to begin with OUTFILE_PREFIX let's be sure not to delete it. 
+	for ext in jats txt jsonld html epub odt docx pdf latex enriched.json flattened.json; do\
+		if [ -f $(OUTFILE_PREFIX).$$ext ]; then rm -f $(OUTFILE_PREFIX).$$ext; fi;\
+	done
+	@#rm -f $(OUTFILE_PREFIX).*
 
 .PHONY: all clean
 


### PR DESCRIPTION
`make clean` should only remove generated files instead of doing `rm OUTFILE_PREFIX.*` 
If ARTICLE_FILE happens to have the same prefix as OUTFILE_PREFIX then running `make clean` currently will currently delete the article source file, destroying any work that isn't backed up! This PR fixes that vulnerability.